### PR TITLE
Modeler does not find virtual routers in 4.0.1

### DIFF
--- a/ZenPacks/zenoss/CloudStack/modeler/plugins/zenoss/CloudStack.py
+++ b/ZenPacks/zenoss/CloudStack/modeler/plugins/zenoss/CloudStack.py
@@ -61,7 +61,7 @@ class CloudStack(PythonPlugin):
             client.listClusters(),
             client.listHosts(type="Routing"),
             client.listSystemVms(),
-            client.listRouters(),
+            client.listRouters(listAll='true'),
             client.listVirtualMachines(domainid='1', isrecursive=True),
             client.listCapacity(),
             ), consumeErrors=True).addCallback(self._combine)


### PR DESCRIPTION
the listroutersresponse is null when listAll is not set true.
