### PR TITLE
Add Zone domain as an attribute

### DIFF
--- a/ZenPacks/zenoss/CloudStack/Zone.py
+++ b/ZenPacks/zenoss/CloudStack/Zone.py
@@ -29,6 +29,7 @@ class Zone(BaseComponent):
     security_groups_enabled = None
     vlan = None
     zone_token = None
+    domain = None
 
     _properties = BaseComponent._properties + (
         {'id': 'guest_cidr_address', 'type': 'string', 'mode': ''},
@@ -41,6 +42,7 @@ class Zone(BaseComponent):
         {'id': 'security_groups_enabled', 'type': 'boolean', 'mode': ''},
         {'id': 'vlan', 'type': 'string', 'mode': ''},
         {'id': 'zone_token', 'type': 'string', 'mode': ''},
+        {'id': 'domain', 'type': 'string', 'mode': ''},
         )
 
     _relations = BaseComponent._relations + (

--- a/ZenPacks/zenoss/CloudStack/info.py
+++ b/ZenPacks/zenoss/CloudStack/info.py
@@ -81,6 +81,7 @@ class ZoneInfo(BaseComponentInfo):
     security_groups_enabled = ProxyProperty('security_groups_enabled')
     vlan = ProxyProperty('vlan')
     zone_token = ProxyProperty('zone_token')
+    domain = ProxyProperty('domain')
 
     @property
     def public_dns(self):

--- a/ZenPacks/zenoss/CloudStack/interfaces.py
+++ b/ZenPacks/zenoss/CloudStack/interfaces.py
@@ -73,6 +73,7 @@ class IZoneInfo(IBaseComponentInfo):
     pod_count = schema.Int(title=_t(u"Pod Count"))
     cluster_count = schema.Int(title=_t(u"Cluster Count"))
     host_count = schema.Int(title=_t(u"Host Count"))
+    domain = SingleLineText(title=_t(u"Zone Domain"))
 
 
 class IPodInfo(IBaseComponentInfo):

--- a/ZenPacks/zenoss/CloudStack/modeler/plugins/zenoss/CloudStack.py
+++ b/ZenPacks/zenoss/CloudStack/modeler/plugins/zenoss/CloudStack.py
@@ -113,7 +113,7 @@ class CloudStack(PythonPlugin):
         zone_maps = []
         for zone in zones_response.get('zone', []):
             zone_id = self.prepId('zone%s' % zone['id'])
-
+	    
             zone_maps.append(ObjectMap(data=dict(
                 id=zone_id,
                 title=zone.get('name', zone_id),
@@ -129,6 +129,7 @@ class CloudStack(PythonPlugin):
                 security_groups_enabled=zone.get('securitygroupsenabled', ''),
                 vlan=zone.get('vlan', ''),
                 zone_token=zone.get('zonetoken', ''),
+                domain=zone.get('domain',zone.get('name', '')),
                 )))
 
         yield RelationshipMap(


### PR DESCRIPTION
Found a need to store the domain associated with a CloudStack zone as an attribute, in order to derive a VMs FQDN as VM-nam.Zone-domain.
